### PR TITLE
Update shape examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The following sample demonstrates how to do it:
 var ovalShape = MSOvalShape.alloc().init();
 ovalShape.frame = MSRect.rectWithRect(NSMakeRect(0,0,100,100));
 
-var shapeGroup=ovalShape.embedInShapeGroup();
+var shapeGroup=MSShapeGroup.shapeWithPath(ovalShape);
 var fill = shapeGroup.style().fills().addNewStylePart();
 fill.color = MSColor.colorWithSVGString("#dd2020");
 

--- a/Samples/Create Oval Shape.sketchplugin
+++ b/Samples/Create Oval Shape.sketchplugin
@@ -5,7 +5,7 @@
     ovalShape.frame = MSRect.rectWithRect(NSMakeRect(0,0,100,100));
 
     // Wrap it with MSShapeGroup and set simple fill style.
-    var shapeGroup=ovalShape.embedInShapeGroup();
+    var shapeGroup=MSShapeGroup.shapeWithPath(ovalShape);
     var fill = shapeGroup.style().fills().addNewStylePart();
     fill.color = MSColor.colorWithSVGString("#dd2020");
 

--- a/Samples/Create Rounded Rect Layer.sketchplugin
+++ b/Samples/Create Rounded Rect Layer.sketchplugin
@@ -6,10 +6,27 @@
     rectLayer.frame = MSRect.rectWithRect(NSMakeRect(10,10,360,240));
     rectLayer.cornerRadiusFloat = 25;
 
-    var shapeGroup=rectLayer.embedInShapeGroup();
+    var shapeGroup=MSShapeGroup.shapeWithPath(rectLayer);
     var fill=shapeGroup.style().fills().addNewStylePart();
     fill.color=MSColor.colorWithSVGString("#dd0000");
 
     doc.currentPage().selectLayers([shapeGroup]);
 
+})();
+
+(function(){
+
+    // Create rectangle object
+    var ovalShape = MSOvalShape.alloc().init();
+    ovalShape.frame = MSRect.rectWithRect(NSMakeRect(0,0,100,100));
+
+    // Wrap it with MSShapeGroup and set simple fill style.
+    var shapeGroup=MSShapeGroup.shapeWithPath(ovalShape);
+    var fill = shapeGroup.style().fills().addNewStylePart();
+    fill.color = MSColor.colorWithSVGString("#dd2020");
+
+    shapeGroup.frame().constrainProportions = false; // Set to `true` if you want shape to be constrained.
+
+    // Add created shape group to the current page.
+    doc.currentPage().addLayers([shapeGroup]);
 })();

--- a/Samples/Create Rounded Rect Layer.sketchplugin
+++ b/Samples/Create Rounded Rect Layer.sketchplugin
@@ -1,29 +1,14 @@
 (function(){
 
-    var parent = doc.currentPage();
-    var rectLayer=parent.addLayerOfType("rectangle");
-
-    rectLayer.frame = MSRect.rectWithRect(NSMakeRect(10,10,360,240));
-    rectLayer.cornerRadiusFloat = 25;
-
-    var shapeGroup=MSShapeGroup.shapeWithPath(rectLayer);
-    var fill=shapeGroup.style().fills().addNewStylePart();
-    fill.color=MSColor.colorWithSVGString("#dd0000");
-
-    doc.currentPage().selectLayers([shapeGroup]);
-
-})();
-
-(function(){
-
     // Create rectangle object
-    var ovalShape = MSOvalShape.alloc().init();
-    ovalShape.frame = MSRect.rectWithRect(NSMakeRect(0,0,100,100));
+    var rectShape = MSRectangleShape.alloc().init();
+    rectShape.frame = MSRect.rectWithRect(NSMakeRect(0,0,100,100));
+rectShape.cornerRadiusFloat = 25;
 
     // Wrap it with MSShapeGroup and set simple fill style.
-    var shapeGroup=MSShapeGroup.shapeWithPath(ovalShape);
+    var shapeGroup=MSShapeGroup.shapeWithPath(rectShape);
     var fill = shapeGroup.style().fills().addNewStylePart();
-    fill.color = MSColor.colorWithSVGString("#dd2020");
+    fill.color = MSColor.colorWithSVGString("#dd0000");
 
     shapeGroup.frame().constrainProportions = false; // Set to `true` if you want shape to be constrained.
 


### PR DESCRIPTION
See http://mail.sketchplugins.com/pipermail/dev_sketchplugins.com/2014-December/001033.html

Also, the fill wasn't working in the rounded rectangle example. I made it consistent with the oval example and now it works.

![image](https://cloud.githubusercontent.com/assets/727778/7777426/b126dc38-0077-11e5-8166-36470cc4e6d8.png)
