### PR TITLE
Added a new resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ typeOf(strB);
 // -> [object MOBoxedObject]
 ```
 
-As you can see, variables `strA` & `strB` are of different types. `strA` is a JavaScript string, but `strB` is a mysterious `MOBoxedObject`. The problem is in definition of `strB` - `@"hello!"` is equal to `NSString.stringWithString("hello!")` and it produces boxed instance of NSString class instead of JS string.
+As you can see, variables `strA` & `strB` are of different types. `strA` is a [JavaScript string](https://www.scaler.com/topics/javascript/javascript-string/), but `strB` is a mysterious `MOBoxedObject`. The problem is in definition of `strB` - `@"hello!"` is equal to `NSString.stringWithString("hello!")` and it produces boxed instance of NSString class instead of JS string.
 
 When developing Sketch plugins, you usually deal with the data that is produced on `Sketch Runtime` side. And most of the property getters and class methods return boxed Objective-C objects instead of native JS objects.
 


### PR DESCRIPTION
Hey, I have added a reference link for JavaScript strings under CocoaScript: Don't use '===' operator. I came upon this article while looking for resources to learn JavaScript. This citation, in my opinion, will enhance the content of this article. Hope that my contribution will benefit other learners.